### PR TITLE
Add Alpine Pod YAML for network testing

### DIFF
--- a/alpine-nettest.yaml
+++ b/alpine-nettest.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-nettest
+spec:
+  restartPolicy: Never
+  containers:
+    - name: alpine
+      image: alpine:latest
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache iputils busybox-extras && \
+          sleep infinity


### PR DESCRIPTION
## Summary
- add Alpine pod manifest for network testing with iputils and busybox-extras

## Testing
- `yamllint alpine-nettest.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f alpine-nettest.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df5bee7c8323b0db0819cec9ef4c