### PR TITLE
Add Unity Catalog OpenShift deployment templates

### DIFF
--- a/exp-misc/alpine-nettest.yaml
+++ b/exp-misc/alpine-nettest.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-nettest
+spec:
+  restartPolicy: Never
+  containers:
+    - name: alpine
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/community \
+            iputils busybox-extras && \
+          sleep infinity

--- a/exp-unitycatalog/configmap.yaml
+++ b/exp-unitycatalog/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: uc-config
+  namespace: ${UC_NAMESPACE}
+data:
+  DB_HOST: ${DB_HOST}
+  S3_ENDPOINT: ${S3_ENDPOINT}

--- a/exp-unitycatalog/deploy.sh
+++ b/exp-unitycatalog/deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Deploy Unity Catalog resources on OpenShift
+# Usage: ./deploy.sh [restart]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/uc-config.env"
+
+OBJECTS=(configmap.yaml secret.yaml deployment.yaml service.yaml route.yaml)
+
+if [[ ${1:-} == "restart" ]]; then
+  echo "Deleting existing Unity Catalog resources..."
+  for obj in "${OBJECTS[@]}"; do
+    envsubst < "${SCRIPT_DIR}/${obj}" | oc delete -f - --ignore-not-found
+  done
+fi
+
+echo "Applying Unity Catalog resources..."
+for obj in "${OBJECTS[@]}"; do
+  envsubst < "${SCRIPT_DIR}/${obj}" | oc apply -f -
+done

--- a/exp-unitycatalog/deployment.yaml
+++ b/exp-unitycatalog/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: uc-deployment
+  namespace: ${UC_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: uc
+  template:
+    metadata:
+      labels:
+        app: uc
+    spec:
+      containers:
+        - name: uc
+          image: ${UC_IMAGE}
+          ports:
+            - containerPort: ${UC_PORT}
+          envFrom:
+            - configMapRef:
+                name: uc-config
+            - secretRef:
+                name: uc-secrets

--- a/exp-unitycatalog/route.yaml
+++ b/exp-unitycatalog/route.yaml
@@ -1,0 +1,12 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: uc-route
+  namespace: ${UC_NAMESPACE}
+spec:
+  to:
+    kind: Service
+    name: uc-service
+  port:
+    targetPort: ${UC_PORT}
+  host: ${UC_ROUTE_HOST}

--- a/exp-unitycatalog/secret.yaml
+++ b/exp-unitycatalog/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uc-secrets
+  namespace: ${UC_NAMESPACE}
+type: Opaque
+stringData:
+  DB_USER: ${DB_USER}
+  DB_PASSWORD: ${DB_PASSWORD}
+  S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+  S3_SECRET_KEY: ${S3_SECRET_KEY}

--- a/exp-unitycatalog/service.yaml
+++ b/exp-unitycatalog/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: uc-service
+  namespace: ${UC_NAMESPACE}
+spec:
+  selector:
+    app: uc
+  ports:
+    - port: ${UC_PORT}
+      targetPort: ${UC_PORT}
+      protocol: TCP

--- a/exp-unitycatalog/uc-config.env
+++ b/exp-unitycatalog/uc-config.env
@@ -1,0 +1,12 @@
+# Common environment configuration for Unity Catalog deployment
+# Update these values to match your environment
+UC_NAMESPACE=unity-catalog
+UC_IMAGE=databricks/unity-catalog:latest
+UC_PORT=8080
+DB_HOST=mydb.example.com
+DB_USER=uc_user
+DB_PASSWORD=uc_pass
+S3_ENDPOINT=https://s3.example.com
+S3_ACCESS_KEY=accesskey
+S3_SECRET_KEY=secretkey
+UC_ROUTE_HOST=uc.example.com


### PR DESCRIPTION
## Summary
- add environment config file for Unity Catalog variables
- add OpenShift manifests for ConfigMap, Secret, Deployment, Service, and Route
- add deploy script with optional restart to recreate resources

## Testing
- `yamllint exp-unitycatalog/configmap.yaml exp-unitycatalog/secret.yaml exp-unitycatalog/deployment.yaml exp-unitycatalog/service.yaml exp-unitycatalog/route.yaml` *(fails: command not found)*
- `bash -n exp-unitycatalog/deploy.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a6df5bee7c8323b0db0819cec9ef4c