### PR TITLE
Add Alpine network test pod

### DIFF
--- a/exp-misc/alpine-nettest.yaml
+++ b/exp-misc/alpine-nettest.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-nettest
+spec:
+  restartPolicy: Never
+  containers:
+    - name: alpine
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/community \
+            iputils busybox-extras curl && \
+          sleep infinity


### PR DESCRIPTION
## Summary
- add an Alpine pod manifest that installs ping, telnet, and curl for connectivity checks
- remove Unity Catalog deployment templates and scripts

## Testing
- `yamllint exp-misc/alpine-nettest.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f exp-misc/alpine-nettest.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df5bee7c8323b0db0819cec9ef4c