### PR TITLE
Add network test pod and S3 bucket usage deployment

### DIFF
--- a/exp-misc/alpine-nettest.yaml
+++ b/exp-misc/alpine-nettest.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-nettest
+spec:
+  restartPolicy: Never
+  containers:
+    - name: alpine
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/community \
+            iputils busybox-extras curl && \
+          sleep infinity

--- a/exp-misc/s3-bucket-usage.yaml
+++ b/exp-misc/s3-bucket-usage.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-bucket-usage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-bucket-usage
+  template:
+    metadata:
+      labels:
+        app: s3-bucket-usage
+    spec:
+      containers:
+          - name: usage
+            image: amazon/aws-cli:latest
+            env:
+              - name: BUCKET
+                value: my-bucket
+              - name: BUCKET_CAPACITY_GB
+                value: "100"
+            envFrom:
+              - secretRef:
+                  name: s3-credentials
+            command:
+              - /bin/sh
+              - -c
+              - |
+                if [ "${AWS_ENDPOINT_URL#http}" = "$AWS_ENDPOINT_URL" ]; then
+                  AWS_ENDPOINT_URL="http://$AWS_ENDPOINT_URL"
+                fi
+                USED=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+                FREE_BYTES=$((CAPACITY_BYTES-USED))
+                USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+                FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+                USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+                echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+                echo "Used: $USED_GB GB"
+                echo "Free: $FREE_GB GB"
+                echo "Usage: $USAGE_PERCENT%"
+                if [ "$USAGE_PERCENT" -gt 98 ]; then
+                  echo "Usage exceeds 98%, deleting objects older than 30 days"
+                  THRESHOLD=$(date -d '30 days ago' +%s)
+                  aws s3 ls s3://$BUCKET --recursive | while read -r line; do
+                    FILE_DATE=$(echo $line | awk '{print $1" "$2}')
+                    FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                    if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                      KEY=$(echo $line | awk '{print $4}')
+                      aws s3 rm s3://$BUCKET/$KEY
+                    fi
+                  done
+                fi
+                sleep infinity


### PR DESCRIPTION
## Summary
- add an Alpine pod manifest that installs ping, telnet, and curl for connectivity checks
- add a deployment that reports S3 bucket usage and free capacity using AWS CLI with credentials from a secret
- ensure custom AWS endpoint variables include an HTTP scheme
- delete S3 objects older than 30 days when usage exceeds 98%

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `yamllint exp-misc/alpine-nettest.yaml exp-misc/s3-bucket-usage.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f exp-misc/alpine-nettest.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f exp-misc/s3-bucket-usage.yaml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6df5bee7c8323b0db0819cec9ef4c