### PR TITLE
Add network test pod and S3 bucket usage deployment

### DIFF
--- a/exp-misc/alpine-nettest.yaml
+++ b/exp-misc/alpine-nettest.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-nettest
+spec:
+  restartPolicy: Never
+  containers:
+    - name: alpine
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/community \
+            iputils busybox-extras curl && \
+          sleep infinity

--- a/exp-misc/s3-bucket-usage-cronjob.yaml
+++ b/exp-misc/s3-bucket-usage-cronjob.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: s3-bucket-usage-cron
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: usage
+              image: amazon/aws-cli:latest
+              env:
+                - name: BUCKET
+                  value: my-bucket
+                - name: BUCKET_CAPACITY_GB
+                  value: "100"
+                - name: EMAIL_FROM
+                  value: sender@example.com
+                - name: EMAIL_TO
+                  value: client@example.com
+              envFrom:
+                - secretRef:
+                    name: s3-credentials
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  if [ "${AWS_ENDPOINT_URL#http}" = "$AWS_ENDPOINT_URL" ]; then
+                    AWS_ENDPOINT_URL="http://$AWS_ENDPOINT_URL"
+                  fi
+                  USED=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                  CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+                  FREE_BYTES=$((CAPACITY_BYTES-USED))
+                  USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+                  FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+                  USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+                  echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+                  echo "Used: $USED_GB GB"
+                  echo "Free: $FREE_GB GB"
+                  echo "Usage: $USAGE_PERCENT%"
+                  if [ "$USAGE_PERCENT" -gt 98 ]; then
+                    echo "Usage exceeds 98%, deleting objects older than 30 days"
+                    THRESHOLD=$(date -d '30 days ago' +%s)
+                    TMP=$(mktemp)
+                    aws s3 ls s3://$BUCKET --recursive > "$TMP"
+                    DELETED_COUNT=0
+                    DELETED_BYTES=0
+                    while read -r line; do
+                      FILE_DATE=$(echo "$line" | awk '{print $1" "$2}')
+                      FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                      if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                        SIZE=$(echo "$line" | awk '{print $3}')
+                        KEY=$(echo "$line" | awk '{print $4}')
+                        aws s3 rm s3://$BUCKET/$KEY
+                        DELETED_COUNT=$((DELETED_COUNT+1))
+                        DELETED_BYTES=$((DELETED_BYTES+SIZE))
+                      fi
+                    done < "$TMP"
+                    rm "$TMP"
+                    USED_AFTER=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                    FREE_AFTER_BYTES=$((CAPACITY_BYTES-USED_AFTER))
+                    USED_AFTER_GB=$(awk "BEGIN {printf \"%.2f\", $USED_AFTER/1024/1024/1024}")
+                    FREE_AFTER_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_AFTER_BYTES/1024/1024/1024}")
+                    DELETED_GB=$(awk "BEGIN {printf \"%.2f\", $DELETED_BYTES/1024/1024/1024}")
+                    MESSAGE=$(printf "Bucket: %s\nDeleted objects: %s\nDeleted size: %s GB\nCapacity: %s GB\nUsed before: %s GB (%s%%)\nFree before: %s GB\nUsed after: %s GB\nFree after: %s GB\n" "$BUCKET" "$DELETED_COUNT" "$DELETED_GB" "$BUCKET_CAPACITY_GB" "$USED_GB" "$USAGE_PERCENT" "$FREE_GB" "$USED_AFTER_GB" "$FREE_AFTER_GB")
+                    aws ses send-email --from "$EMAIL_FROM" --destination "ToAddresses=$EMAIL_TO" --message "Subject={Data='S3 cleanup report'},Body={Text={Data='$MESSAGE'}}"
+                  fi
+

--- a/exp-misc/s3-bucket-usage-job.yaml
+++ b/exp-misc/s3-bucket-usage-job.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: s3-bucket-usage-job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: usage
+          image: amazon/aws-cli:latest
+          env:
+            - name: BUCKET
+              value: my-bucket
+            - name: BUCKET_CAPACITY_GB
+              value: "100"
+          envFrom:
+            - secretRef:
+                name: s3-credentials
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ "${AWS_ENDPOINT_URL#http}" = "$AWS_ENDPOINT_URL" ]; then
+                AWS_ENDPOINT_URL="http://$AWS_ENDPOINT_URL"
+              fi
+              USED=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+              CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+              FREE_BYTES=$((CAPACITY_BYTES-USED))
+              USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+              FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+              USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+              echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+              echo "Used: $USED_GB GB"
+              echo "Free: $FREE_GB GB"
+              echo "Usage: $USAGE_PERCENT%"
+              if [ "$USAGE_PERCENT" -gt 98 ]; then
+                echo "Usage exceeds 98%, deleting objects older than 30 days"
+                THRESHOLD=$(date -d '30 days ago' +%s)
+                aws s3 ls s3://$BUCKET --recursive | while read -r line; do
+                  FILE_DATE=$(echo $line | awk '{print $1" "$2}')
+                  FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                  if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                    KEY=$(echo $line | awk '{print $4}')
+                    aws s3 rm s3://$BUCKET/$KEY
+                  fi
+                done
+              fi

--- a/exp-misc/s3-bucket-usage.yaml
+++ b/exp-misc/s3-bucket-usage.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-bucket-usage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-bucket-usage
+  template:
+    metadata:
+      labels:
+        app: s3-bucket-usage
+    spec:
+      containers:
+          - name: usage
+            image: amazon/aws-cli:latest
+            env:
+              - name: BUCKET
+                value: my-bucket
+              - name: BUCKET_CAPACITY_GB
+                value: "100"
+            envFrom:
+              - secretRef:
+                  name: s3-credentials
+            command:
+              - /bin/sh
+              - -c
+              - |
+                if [ "${AWS_ENDPOINT_URL#http}" = "$AWS_ENDPOINT_URL" ]; then
+                  AWS_ENDPOINT_URL="http://$AWS_ENDPOINT_URL"
+                fi
+                USED=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+                FREE_BYTES=$((CAPACITY_BYTES-USED))
+                USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+                FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+                USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+                echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+                echo "Used: $USED_GB GB"
+                echo "Free: $FREE_GB GB"
+                echo "Usage: $USAGE_PERCENT%"
+                if [ "$USAGE_PERCENT" -gt 98 ]; then
+                  echo "Usage exceeds 98%, deleting objects older than 30 days"
+                  THRESHOLD=$(date -d '30 days ago' +%s)
+                  aws s3 ls s3://$BUCKET --recursive | while read -r line; do
+                    FILE_DATE=$(echo $line | awk '{print $1" "$2}')
+                    FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                    if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                      KEY=$(echo $line | awk '{print $4}')
+                      aws s3 rm s3://$BUCKET/$KEY
+                    fi
+                  done
+                fi
+                sleep infinity


### PR DESCRIPTION
## Summary
- add an Alpine pod manifest that installs ping, telnet, and curl for connectivity checks
- add a deployment that reports S3 bucket usage and free capacity using AWS CLI with credentials from a secret
- ensure custom AWS endpoint variables include an HTTP scheme
- delete S3 objects older than 30 days when usage exceeds 98%
- add a job that performs the same bucket usage check and cleanup once
- schedule periodic bucket cleanup with a CronJob using the same logic
- send an email report after CronJob cleanup summarizing deleted object count and storage stats

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `yamllint exp-misc/s3-bucket-usage-cronjob.yaml` *(fails: command not found)*
- `kubectl apply --dry-run=client -f exp-misc/s3-bucket-usage-cronjob.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6df5bee7c8323b0db0819cec9ef4c