### PR TITLE
Tune S3 cleanup cron threshold and interval

### DIFF
--- a/exp-misc/dwhtrans-alpine-nettest-pod.yaml
+++ b/exp-misc/dwhtrans-alpine-nettest-pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine-nettest-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: alpine
+      image: alpine:latest
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
+            --repository http://dl-cdn.alpinelinux.org/alpine/latest-stable/community \
+            iputils busybox-extras curl && \
+          sleep infinity

--- a/exp-misc/dwhtrans-pvc-cleanup-dep.yaml
+++ b/exp-misc/dwhtrans-pvc-cleanup-dep.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spark-scripts-pvc2-cleanup-dep
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spark-scripts-pvc2-cleanup
+  template:
+    metadata:
+      labels:
+        app: spark-scripts-pvc2-cleanup
+    spec:
+      containers:
+        - name: cleanup
+          image: alpine:latest
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          command:
+            - /bin/sh
+            - -c
+            - |
+              USED_PERCENT=$(df -P /scripts | awk 'NR==2 {print $5}' | tr -d '%')
+              echo "Usage: ${USED_PERCENT}%"
+              if [ "$USED_PERCENT" -ge 99 ]; then
+                echo "Usage above 99%, deleting all data in /scripts"
+                rm -rf /scripts/*
+              fi
+              sleep infinity
+      volumes:
+        - name: scripts
+          persistentVolumeClaim:
+            claimName: spark-scripts-pvc2

--- a/exp-misc/dwhtrans-s3-bucket-usage-cj.yaml
+++ b/exp-misc/dwhtrans-s3-bucket-usage-cj.yaml
@@ -1,0 +1,74 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dwhtrans-s3-bucket-usage-cj
+spec:
+  schedule: "*/20 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: usage
+              image: amazon/aws-cli:latest
+              env:
+                - name: BUCKET
+                  value: my-bucket
+                - name: BUCKET_CAPACITY_GB
+                  value: "100"
+                - name: EMAIL_FROM
+                  value: sender@example.com
+                - name: EMAIL_TO
+                  value: client@example.com
+                - name: AWS_REGION
+                  value: us-east-1
+              envFrom:
+                - secretRef:
+                    name: s3-credentials
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  S3_ENDPOINT="$AWS_ENDPOINT_URL"
+                  if [ "${S3_ENDPOINT#http}" = "$S3_ENDPOINT" ]; then
+                    S3_ENDPOINT="http://$S3_ENDPOINT"
+                  fi
+                  USED=$(aws --endpoint-url "$S3_ENDPOINT" s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                  CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+                  FREE_BYTES=$((CAPACITY_BYTES-USED))
+                  USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+                  FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+                  USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+                  echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+                  echo "Used: $USED_GB GB"
+                  echo "Free: $FREE_GB GB"
+                  echo "Usage: $USAGE_PERCENT%"
+                  if [ "$USAGE_PERCENT" -gt 60 ]; then
+                    echo "Usage exceeds 60%, deleting objects older than 30 days"
+                    THRESHOLD=$(date -d '30 days ago' +%s)
+                    TMP=$(mktemp)
+                    aws --endpoint-url "$S3_ENDPOINT" s3 ls s3://$BUCKET --recursive > "$TMP"
+                    DELETED_COUNT=0
+                    DELETED_BYTES=0
+                    while read -r line; do
+                      FILE_DATE=$(echo "$line" | awk '{print $1" "$2}')
+                      FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                      if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                        SIZE=$(echo "$line" | awk '{print $3}')
+                        KEY=$(echo "$line" | awk '{print $4}')
+                        aws --endpoint-url "$S3_ENDPOINT" s3 rm s3://$BUCKET/$KEY
+                        DELETED_COUNT=$((DELETED_COUNT+1))
+                        DELETED_BYTES=$((DELETED_BYTES+SIZE))
+                      fi
+                    done < "$TMP"
+                    rm "$TMP"
+                    USED_AFTER=$(aws --endpoint-url "$S3_ENDPOINT" s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                    FREE_AFTER_BYTES=$((CAPACITY_BYTES-USED_AFTER))
+                    USED_AFTER_GB=$(awk "BEGIN {printf \"%.2f\", $USED_AFTER/1024/1024/1024}")
+                    FREE_AFTER_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_AFTER_BYTES/1024/1024/1024}")
+                    DELETED_GB=$(awk "BEGIN {printf \"%.2f\", $DELETED_BYTES/1024/1024/1024}")
+                    MESSAGE=$(printf "Bucket: %s\nDeleted objects: %s\nDeleted size: %s GB\nCapacity: %s GB\nUsed before: %s GB (%s%%)\nFree before: %s GB\nUsed after: %s GB\nFree after: %s GB\n" "$BUCKET" "$DELETED_COUNT" "$DELETED_GB" "$BUCKET_CAPACITY_GB" "$USED_GB" "$USAGE_PERCENT" "$FREE_GB" "$USED_AFTER_GB" "$FREE_AFTER_GB")
+                    unset AWS_ENDPOINT_URL
+                    aws ses send-email --from "$EMAIL_FROM" --destination "ToAddresses=$EMAIL_TO" --message "Subject={Data='S3 cleanup report'},Body={Text={Data='$MESSAGE'}}"
+                  fi

--- a/exp-misc/dwhtrans-s3-bucket-usage-cj.yaml
+++ b/exp-misc/dwhtrans-s3-bucket-usage-cj.yaml
@@ -17,10 +17,6 @@ spec:
                   value: my-bucket
                 - name: BUCKET_CAPACITY_GB
                   value: "100"
-                - name: EMAIL_FROM
-                  value: sender@example.com
-                - name: EMAIL_TO
-                  value: client@example.com
                 - name: AWS_REGION
                   value: us-east-1
               envFrom:
@@ -68,7 +64,8 @@ spec:
                     USED_AFTER_GB=$(awk "BEGIN {printf \"%.2f\", $USED_AFTER/1024/1024/1024}")
                     FREE_AFTER_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_AFTER_BYTES/1024/1024/1024}")
                     DELETED_GB=$(awk "BEGIN {printf \"%.2f\", $DELETED_BYTES/1024/1024/1024}")
-                    MESSAGE=$(printf "Bucket: %s\nDeleted objects: %s\nDeleted size: %s GB\nCapacity: %s GB\nUsed before: %s GB (%s%%)\nFree before: %s GB\nUsed after: %s GB\nFree after: %s GB\n" "$BUCKET" "$DELETED_COUNT" "$DELETED_GB" "$BUCKET_CAPACITY_GB" "$USED_GB" "$USAGE_PERCENT" "$FREE_GB" "$USED_AFTER_GB" "$FREE_AFTER_GB")
-                    unset AWS_ENDPOINT_URL
-                    aws ses send-email --from "$EMAIL_FROM" --destination "ToAddresses=$EMAIL_TO" --message "Subject={Data='S3 cleanup report'},Body={Text={Data='$MESSAGE'}}"
+                    echo "Deleted objects: $DELETED_COUNT"
+                    echo "Deleted size: $DELETED_GB GB"
+                    echo "Used after: $USED_AFTER_GB GB"
+                    echo "Free after: $FREE_AFTER_GB GB"
                   fi

--- a/exp-misc/dwhtrans-s3-bucket-usage-dep.yaml
+++ b/exp-misc/dwhtrans-s3-bucket-usage-dep.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-bucket-usage-dep
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-bucket-usage
+  template:
+    metadata:
+      labels:
+        app: s3-bucket-usage
+    spec:
+      containers:
+          - name: usage
+            image: amazon/aws-cli:latest
+            env:
+              - name: BUCKET
+                value: my-bucket
+              - name: BUCKET_CAPACITY_GB
+                value: "100"
+              - name: AWS_REGION
+                value: us-east-1
+            envFrom:
+              - secretRef:
+                  name: s3-credentials
+            command:
+              - /bin/sh
+              - -c
+              - |
+                if [ "${AWS_ENDPOINT_URL#http}" = "$AWS_ENDPOINT_URL" ]; then
+                  AWS_ENDPOINT_URL="http://$AWS_ENDPOINT_URL"
+                fi
+                USED=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+                CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+                FREE_BYTES=$((CAPACITY_BYTES-USED))
+                USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+                FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+                USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+                echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+                echo "Used: $USED_GB GB"
+                echo "Free: $FREE_GB GB"
+                echo "Usage: $USAGE_PERCENT%"
+                if [ "$USAGE_PERCENT" -gt 98 ]; then
+                  echo "Usage exceeds 98%, deleting objects older than 30 days"
+                  THRESHOLD=$(date -d '30 days ago' +%s)
+                  aws s3 ls s3://$BUCKET --recursive | while read -r line; do
+                    FILE_DATE=$(echo $line | awk '{print $1" "$2}')
+                    FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                    if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                      KEY=$(echo $line | awk '{print $4}')
+                      aws s3 rm s3://$BUCKET/$KEY
+                    fi
+                  done
+                fi
+                sleep infinity

--- a/exp-misc/dwhtrans-s3-bucket-usage-job.yaml
+++ b/exp-misc/dwhtrans-s3-bucket-usage-job.yaml
@@ -1,0 +1,50 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: s3-bucket-usage-job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: usage
+          image: amazon/aws-cli:latest
+          env:
+            - name: BUCKET
+              value: my-bucket
+            - name: BUCKET_CAPACITY_GB
+              value: "100"
+            - name: AWS_REGION
+              value: us-east-1
+          envFrom:
+            - secretRef:
+                name: s3-credentials
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ "${AWS_ENDPOINT_URL#http}" = "$AWS_ENDPOINT_URL" ]; then
+                AWS_ENDPOINT_URL="http://$AWS_ENDPOINT_URL"
+              fi
+              USED=$(aws s3 ls s3://$BUCKET --recursive --summarize | awk '/Total Size/ {print $3}')
+              CAPACITY_BYTES=$((BUCKET_CAPACITY_GB*1024*1024*1024))
+              FREE_BYTES=$((CAPACITY_BYTES-USED))
+              USED_GB=$(awk "BEGIN {printf \"%.2f\", $USED/1024/1024/1024}")
+              FREE_GB=$(awk "BEGIN {printf \"%.2f\", $FREE_BYTES/1024/1024/1024}")
+              USAGE_PERCENT=$((USED*100/CAPACITY_BYTES))
+              echo "Bucket capacity: $BUCKET_CAPACITY_GB GB"
+              echo "Used: $USED_GB GB"
+              echo "Free: $FREE_GB GB"
+              echo "Usage: $USAGE_PERCENT%"
+              if [ "$USAGE_PERCENT" -gt 98 ]; then
+                echo "Usage exceeds 98%, deleting objects older than 30 days"
+                THRESHOLD=$(date -d '30 days ago' +%s)
+                aws s3 ls s3://$BUCKET --recursive | while read -r line; do
+                  FILE_DATE=$(echo $line | awk '{print $1" "$2}')
+                  FILE_EPOCH=$(date -d "$FILE_DATE" +%s)
+                  if [ $FILE_EPOCH -lt $THRESHOLD ]; then
+                    KEY=$(echo $line | awk '{print $4}')
+                    aws s3 rm s3://$BUCKET/$KEY
+                  fi
+                done
+              fi


### PR DESCRIPTION
## Summary
- run dwhtrans-s3-bucket-usage-cj every 20 minutes
- start deleting files when bucket usage exceeds 60%

## Testing
- `pip install yamllint` (fails: Could not find a version that satisfies the requirement yamllint)
- `yamllint exp-misc/dwhtrans-s3-bucket-usage-cj.yaml` (fails: command not found)
- `kubectl apply --dry-run=client -f exp-misc/dwhtrans-s3-bucket-usage-cj.yaml` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a6df5bee7c8323b0db0819cec9ef4c