### PR TITLE
Centralize Hive catalog configuration

### DIFF
--- a/exp-hive-catalog/README.md
+++ b/exp-hive-catalog/README.md
@@ -1,0 +1,155 @@
+# Hive Catalog Experiments
+
+This directory contains manifests and experiments related to running a Hive
+metastore-backed catalog on OpenShift with NetApp StorageGRID object storage.
+
+## Contents
+
+* `dwhtrans-catalog-settings.env` – Central configuration file consumed by the
+  manifests and helper scripts. Update the values in this file to tailor the
+  deployment for a specific client before applying anything.
+* `dwhtrans-catalog-serviceaccount-01.yaml` – Service account used by
+  both the metastore and backing database pods.
+* `dwhtrans-catalog-s3-secret-02.yaml` – Secret containing the NetApp S3
+  access key, secret key, bucket, endpoint, and region values consumed by the
+  metastore deployment.
+* `dwhtrans-catalog-configmap-03.yaml` – Hive configuration bundled as a
+  ConfigMap with starter `hive-site.xml` and `core-site.xml` files pointed at the
+  NetApp StorageGRID warehouse buckets.
+* `dwhtrans-catalog-db-secret-04.yaml` – Sample secret providing database
+  credentials. Update the placeholder password prior to deployment.
+* `dwhtrans-catalog-postgres-05.yaml` – PostgreSQL StatefulSet and
+  Service for the metastore schema store.
+* `dwhtrans-catalog-service-06.yaml` – ClusterIP service exposing the
+  metastore thrift endpoint.
+* `dwhtrans-catalog-deployment-07.yaml` – Deployment of the Hive
+  metastore container with mounts and environment variables to reach NetApp S3.
+* `dwhtrans-catalog-schema-loader-pvc-08.yaml` – PersistentVolumeClaim
+  that stores the downloaded schema artifacts from NetApp S3 for the loader pod.
+* `dwhtrans-catalog-schema-loader-deployment-09.yaml` – Auxiliary
+  deployment that syncs the latest schema definition from S3 and executes the
+  Hive DDL it contains against the metastore.
+* `dwhtrans-catalog-validate.sh` – Helper script that waits for the
+  deployment to become available and performs a basic health probe from inside
+  the metastore pod.
+
+Apply the manifests in the order listed to stand up a fully functional Hive
+metastore suitable for experimentation. Ensure a compatible storage class is
+available for the PostgreSQL persistent volume claim.
+
+### Central configuration file
+
+The `dwhtrans-catalog-settings.env` file captures every customizable value used
+by the manifests, from resource names and container images to S3 endpoints,
+credentials placeholders, and storage requests. Both helper scripts source the
+file and the manifests are rendered with `envsubst`, so editing this single file
+is all that is required to adapt the stack for a specific client. Default
+entries act as documentation—replace the placeholder secrets and adjust the
+resource settings before running any automation.
+
+### One-step apply script
+
+Run `./dwhtrans-catalog-apply.sh` from this directory to apply the manifests in
+sequence with a single command. The script defaults to using the `oc` CLI, but
+you can set `KUBECTL=kubectl` (or any other compatible binary) before running
+it. Pass a namespace as the first argument if you want to apply the manifests to
+something other than the current CLI context, for example:
+
+```bash
+KUBECTL=oc ./dwhtrans-catalog-apply.sh my-catalog-namespace
+```
+
+All manifests share the label `app.kubernetes.io/part-of=dwhtrans-catalog`, so a
+simple `oc get pods -l app.kubernetes.io/part-of=dwhtrans-catalog` will return
+every workload that belongs to this catalog experiment.
+
+### Validating the metastore
+
+After the manifests are applied and the pods have started, execute
+`./dwhtrans-catalog-validate.sh` (optionally passing the namespace as the first
+argument) to confirm the deployment is healthy. The script:
+
+1. Waits for `dwhtrans-catalog-deployment` to report as available.
+2. Locates the metastore pod via the shared catalog labels.
+3. Runs `schematool -info` inside the pod to verify connectivity with the
+   PostgreSQL backing store.
+4. Opens a local TCP connection to port 9083 from inside the pod to confirm the
+   metastore thrift endpoint is accepting requests.
+
+Any failure in these checks stops the script with a non-zero exit code so
+automations can detect a problem quickly.
+
+## Customizing for client deployments
+
+When adapting the catalog stack for a specific client environment, edit
+`dwhtrans-catalog-settings.env` and adjust the groups of variables below before
+applying the manifests or running either script:
+
+* **Namespace** – Pass the target namespace to
+  `./dwhtrans-catalog-apply.sh <namespace>` (or set `-n <namespace>` manually if
+  applying manifests yourself). Namespaces are intentionally left out of the
+  manifests so the same templates work across clusters.
+* **Identity and labels** – Customize `DWT_APP_NAME`, `DWT_PART_OF_LABEL`,
+  `DWT_LABEL_AREA`, and the component variables to align with client naming and
+  governance standards. Every manifest references these settings for selectors
+  and labels.
+* **Service account** – Override `DWT_SERVICE_ACCOUNT_NAME` (and, if needed,
+  add annotations directly to the YAML) when a client supplies a pre-created
+  account or wants a different name.
+* **S3 access** – Set `DWT_S3_ACCESS_KEY`, `DWT_S3_SECRET_KEY`, `DWT_S3_BUCKET`,
+  `DWT_S3_ENDPOINT`, `DWT_S3_REGION`, and related toggles such as
+  `DWT_S3_PATH_STYLE` or `DWT_S3_SSL_ENABLED` to match the NetApp StorageGRID
+  environment. `DWT_S3_SCHEMA_PREFIX` determines which folder the schema loader
+  monitors for new Hive DDL.
+* **Database settings** – Adjust `DWT_DB_IMAGE`, `DWT_DB_NAME`,
+  `DWT_DB_USERNAME`, `DWT_DB_PASSWORD`, `DWT_DB_STORAGE_SIZE`, and the resource
+  requests/limits to match the client's policy or an external database service.
+  Update `DWT_DB_SERVICE_NAME` and related variables if integrating with a
+  managed PostgreSQL offering.
+* **Metastore workload sizing** – Tune `DWT_METASTORE_IMAGE`,
+  `DWT_METASTORE_REPLICAS`, the resource requests/limits, and
+  `DWT_METASTORE_JAVA_TOOL_OPTIONS` for production-grade deployments.
+* **Schema loader specifics** – Modify the schema loader images, replica count,
+  and storage (`DWT_SCHEMA_*` variables) if the client needs different tooling or
+  a larger scratch space for downloaded DDL artifacts.
+
+After updating the environment file, rerun the apply script so that the rendered
+manifests pick up the new values. Remember to rotate any secrets stored in the
+file according to the client's credential lifecycle policies.
+
+## NetApp StorageGRID configuration
+
+Update the related entries in `dwhtrans-catalog-settings.env` before applying
+the manifests so the rendered resources contain the correct NetApp details:
+
+* `DWT_S3_ACCESS_KEY`, `DWT_S3_SECRET_KEY`, `DWT_S3_ENDPOINT`, `DWT_S3_BUCKET`,
+  and `DWT_S3_REGION` populate the S3 secret and environment variables used by
+  the Hive pods.
+* Warehouse directories, `fs.s3a.endpoint`, region, and access style values
+  (`DWT_S3_BUCKET`, `DWT_S3_ENDPOINT`, `DWT_S3_REGION`, `DWT_S3_PATH_STYLE`, and
+  `DWT_S3_SSL_ENABLED`) shape the `hive-site.xml` and `core-site.xml` data in the
+  ConfigMap. Provide the endpoint without a scheme (for example
+  `storagegrid.example.com:10443`).
+
+The deployment injects the S3 credentials as `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` environment variables and mounts the Hadoop `core-site`
+configuration so that Hive can access NetApp StorageGRID via the S3A connector.
+Helper variables `S3_ENDPOINT` and `S3_BUCKET` are also exposed to simplify
+debugging and downstream job configuration.
+
+### Automatic schema registration
+
+The schema loader deployment runs alongside the metastore to keep table
+definitions in sync with the contents of a NetApp S3 folder:
+
+1. An init container based on the AWS CLI lists the keys under
+   `SCHEMA_S3_PREFIX` and copies the most recently modified object onto the PVC
+   created by `dwhtrans-catalog-schema-loader-pvc-08.yaml`.
+2. The main container uses the Hive CLI to run the downloaded `.sql` or `.hql`
+   file so that any `CREATE TABLE` statements are registered in the metastore.
+3. The pod remains running after a successful execution so you can inspect the
+   logs or rerun the pod if a new schema needs to be applied.
+
+Before deploying to a client environment, set `DWT_S3_SCHEMA_PREFIX` in the
+environment file to the folder that contains the DDL artifacts and confirm the
+credentials injected from the S3 secret have permission to read the objects.

--- a/exp-hive-catalog/dwhtrans-catalog-apply.sh
+++ b/exp-hive-catalog/dwhtrans-catalog-apply.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Allow overriding the CLI via KUBECTL env var, default to oc for OpenShift.
+KUBECTL_BIN="${KUBECTL:-oc}"
+if ! command -v "${KUBECTL_BIN}" >/dev/null 2>&1; then
+  echo "error: required CLI '${KUBECTL_BIN}' not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "error: required CLI 'envsubst' not found in PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/dwhtrans-catalog-settings.env"
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "error: configuration file ${CONFIG_FILE} not found" >&2
+  exit 1
+fi
+
+# Collect variable names before sourcing so we can scope envsubst
+declare -a CONFIG_VARS=()
+declare -A SEEN_VARS=()
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  [[ "${line}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+  var_name="${line%%=*}"
+  if [[ -z "${SEEN_VARS["${var_name}"]+x}" ]]; then
+    CONFIG_VARS+=("${var_name}")
+    SEEN_VARS["${var_name}"]=1
+  fi
+done < "${CONFIG_FILE}"
+
+set -a
+# shellcheck disable=SC1090
+source "${CONFIG_FILE}"
+set +a
+
+envsubst_args=""
+if [[ ${#CONFIG_VARS[@]} -gt 0 ]]; then
+  envsubst_args="$(printf '${%s} ' "${CONFIG_VARS[@]}")"
+  envsubst_args="${envsubst_args% }"
+fi
+
+# Optional namespace argument; leave empty to use the current CLI context.
+NAMESPACE="${1:-}"
+
+manifests=(
+  "dwhtrans-catalog-serviceaccount-01.yaml"
+  "dwhtrans-catalog-s3-secret-02.yaml"
+  "dwhtrans-catalog-configmap-03.yaml"
+  "dwhtrans-catalog-db-secret-04.yaml"
+  "dwhtrans-catalog-postgres-05.yaml"
+  "dwhtrans-catalog-service-06.yaml"
+  "dwhtrans-catalog-deployment-07.yaml"
+  "dwhtrans-catalog-schema-loader-pvc-08.yaml"
+  "dwhtrans-catalog-schema-loader-deployment-09.yaml"
+)
+
+apply_args=()
+if [[ -n "${NAMESPACE}" ]]; then
+  apply_args+=("-n" "${NAMESPACE}")
+fi
+
+for manifest in "${manifests[@]}"; do
+  manifest_path="${SCRIPT_DIR}/${manifest}"
+  if [[ ! -f "${manifest_path}" ]]; then
+    echo "error: manifest ${manifest_path} not found" >&2
+    exit 1
+  fi
+
+  echo "Applying ${manifest}"
+  if [[ -n "${envsubst_args}" ]]; then
+    envsubst "${envsubst_args}" < "${manifest_path}" | \
+      "${KUBECTL_BIN}" apply -f - "${apply_args[@]}"
+  else
+    cat "${manifest_path}" | \
+      "${KUBECTL_BIN}" apply -f - "${apply_args[@]}"
+  fi
+done

--- a/exp-hive-catalog/dwhtrans-catalog-configmap-03.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-configmap-03.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${DWT_CONFIGMAP_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+  annotations:
+    openshift.io/display-name: Hive Metastore Configuration
+    openshift.io/description: |
+      Configuration for the Hive metastore service including JDBC connectivity,
+      storage handler settings, and NetApp S3 warehouse integration. Update the
+      values to match the target environment before deployment.
+data:
+  hive-site.xml: |
+    <?xml version="1.0"?>
+    <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+    <configuration>
+      <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:postgresql://${DWT_DB_SERVICE_NAME}:${DWT_DB_PORT}/${DWT_DB_NAME}</value>
+        <description>JDBC connection URL for the Hive metastore backing database.</description>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>org.postgresql.Driver</value>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>${DWT_DB_USERNAME}</value>
+      </property>
+      <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>${HIVE_METASTORE_DB_PASSWORD}</value>
+      </property>
+      <property>
+        <name>datanucleus.autoCreateSchema</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>datanucleus.schema.autoCreateAll</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://0.0.0.0:${DWT_METASTORE_THRIFT_PORT}</value>
+        <description>Thrift URI where the metastore listens for connections.</description>
+      </property>
+      <property>
+        <name>hive.metastore.metrics.enabled</name>
+        <value>true</value>
+      </property>
+      <property>
+        <name>hive.metastore.warehouse.dir</name>
+        <value>s3a://${DWT_S3_BUCKET}/warehouse</value>
+        <description>Primary warehouse path hosted on NetApp StorageGRID S3.</description>
+      </property>
+      <property>
+        <name>hive.metastore.warehouse.external.dir</name>
+        <value>s3a://${DWT_S3_BUCKET}/external</value>
+        <description>Location for external tables stored in NetApp StorageGRID S3.</description>
+      </property>
+    </configuration>
+  core-site.xml: |
+    <?xml version="1.0"?>
+    <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+    <configuration>
+      <property>
+        <name>fs.defaultFS</name>
+        <value>s3a://${DWT_S3_BUCKET}</value>
+        <description>Use the NetApp StorageGRID bucket as the default filesystem.</description>
+      </property>
+      <property>
+        <name>fs.s3a.endpoint</name>
+        <value>${DWT_S3_ENDPOINT}</value>
+        <description>NetApp StorageGRID S3 endpoint hostname.</description>
+      </property>
+      <property>
+        <name>fs.s3a.endpoint.region</name>
+        <value>${DWT_S3_REGION}</value>
+      </property>
+      <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>${DWT_S3_PATH_STYLE}</value>
+      </property>
+      <property>
+        <name>fs.s3a.connection.ssl.enabled</name>
+        <value>${DWT_S3_SSL_ENABLED}</value>
+      </property>
+      <property>
+        <name>fs.s3a.aws.credentials.provider</name>
+        <value>org.apache.hadoop.fs.s3a.EnvironmentVariableCredentialsProvider</value>
+        <description>Source S3 credentials from the AWS_* environment variables.</description>
+      </property>
+      <property>
+        <name>fs.s3a.impl.disable.cache</name>
+        <value>true</value>
+      </property>
+    </configuration>

--- a/exp-hive-catalog/dwhtrans-catalog-db-secret-04.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-db-secret-04.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${DWT_DB_SECRET_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+type: Opaque
+stringData:
+  username: ${DWT_DB_USERNAME}
+  password: ${DWT_DB_PASSWORD}

--- a/exp-hive-catalog/dwhtrans-catalog-deployment-07.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-deployment-07.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${DWT_METASTORE_DEPLOYMENT_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+spec:
+  replicas: ${DWT_METASTORE_REPLICAS}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${DWT_APP_NAME}
+      app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${DWT_APP_NAME}
+        app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+        app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+        exp.openshift.io/area: ${DWT_LABEL_AREA}
+    spec:
+      serviceAccountName: ${DWT_SERVICE_ACCOUNT_NAME}
+      containers:
+        - name: metastore
+          image: ${DWT_METASTORE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: ${DWT_METASTORE_THRIFT_PORT}
+              name: thrift
+          env:
+            - name: HIVE_METASTORE_DB_HOST
+              value: ${DWT_DB_SERVICE_NAME}
+            - name: HIVE_METASTORE_DB_PORT
+              value: "${DWT_DB_PORT}"
+            - name: HIVE_METASTORE_DB_NAME
+              value: ${DWT_DB_NAME}
+            - name: HIVE_METASTORE_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_DB_SECRET_NAME}
+                  key: username
+            - name: HIVE_METASTORE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_DB_SECRET_NAME}
+                  key: password
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: accessKey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: secretKey
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: region
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: endpoint
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: bucket
+            - name: JAVA_TOOL_OPTIONS
+              value: "${DWT_METASTORE_JAVA_TOOL_OPTIONS}"
+          readinessProbe:
+            tcpSocket:
+              port: thrift
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: thrift
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          volumeMounts:
+            - name: hive-config
+              mountPath: /opt/hive/conf/hive-site.xml
+              subPath: hive-site.xml
+            - name: hive-config
+              mountPath: /opt/hadoop/conf/core-site.xml
+              subPath: core-site.xml
+          resources:
+            requests:
+              cpu: ${DWT_METASTORE_CPU_REQUEST}
+              memory: ${DWT_METASTORE_MEMORY_REQUEST}
+            limits:
+              cpu: ${DWT_METASTORE_CPU_LIMIT}
+              memory: ${DWT_METASTORE_MEMORY_LIMIT}
+      volumes:
+        - name: hive-config
+          configMap:
+            name: ${DWT_CONFIGMAP_NAME}
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 185
+      restartPolicy: Always

--- a/exp-hive-catalog/dwhtrans-catalog-postgres-05.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-postgres-05.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${DWT_DB_STATEFULSET_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+spec:
+  serviceName: ${DWT_DB_SERVICE_NAME}
+  replicas: ${DWT_DB_REPLICAS}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${DWT_APP_NAME}
+      app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${DWT_APP_NAME}
+        app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+        app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+        exp.openshift.io/area: ${DWT_LABEL_AREA}
+    spec:
+      serviceAccountName: ${DWT_SERVICE_ACCOUNT_NAME}
+      containers:
+        - name: postgres
+          image: ${DWT_DB_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: ${DWT_DB_PORT}
+              name: postgres
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_DB_SECRET_NAME}
+                  key: username
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_DB_SECRET_NAME}
+                  key: password
+            - name: POSTGRESQL_DATABASE
+              value: ${DWT_DB_NAME}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/pgsql/data
+          resources:
+            requests:
+              cpu: ${DWT_DB_CPU_REQUEST}
+              memory: ${DWT_DB_MEMORY_REQUEST}
+            limits:
+              cpu: ${DWT_DB_CPU_LIMIT}
+              memory: ${DWT_DB_MEMORY_LIMIT}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: ${DWT_APP_NAME}
+          app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+          app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: ${DWT_DB_STORAGE_SIZE}
+        storageClassName: ${DWT_DB_STORAGE_CLASS}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${DWT_DB_SERVICE_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+spec:
+  selector:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/component: ${DWT_COMPONENT_DATABASE}
+  ports:
+    - name: postgres
+      port: ${DWT_DB_PORT}
+      targetPort: postgres
+  type: ClusterIP

--- a/exp-hive-catalog/dwhtrans-catalog-s3-secret-02.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-s3-secret-02.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${DWT_S3_SECRET_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+  annotations:
+    openshift.io/display-name: NetApp S3 Access Credentials
+    openshift.io/description: |
+      Provide the NetApp StorageGRID S3 credentials and connection metadata used
+      by the Hive metastore to talk to the object storage warehouse. Replace the
+      placeholder values with your actual access key, secret key, and endpoint
+      before applying the manifest.
+type: Opaque
+stringData:
+  accessKey: ${DWT_S3_ACCESS_KEY}
+  secretKey: ${DWT_S3_SECRET_KEY}
+  region: ${DWT_S3_REGION}
+  endpoint: ${DWT_S3_ENDPOINT}
+  bucket: ${DWT_S3_BUCKET}

--- a/exp-hive-catalog/dwhtrans-catalog-schema-loader-deployment-09.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-schema-loader-deployment-09.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${DWT_SCHEMA_LOADER_DEPLOYMENT_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_SCHEMA_LOADER}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+spec:
+  replicas: ${DWT_SCHEMA_LOADER_REPLICAS}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ${DWT_APP_NAME}
+      app.kubernetes.io/component: ${DWT_COMPONENT_SCHEMA_LOADER}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${DWT_APP_NAME}
+        app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+        app.kubernetes.io/component: ${DWT_COMPONENT_SCHEMA_LOADER}
+        exp.openshift.io/area: ${DWT_LABEL_AREA}
+    spec:
+      serviceAccountName: ${DWT_SERVICE_ACCOUNT_NAME}
+      initContainers:
+        - name: schema-sync
+          image: ${DWT_SCHEMA_SYNC_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: accessKey
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: secretKey
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: region
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: endpoint
+            - name: S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: ${DWT_S3_SECRET_NAME}
+                  key: bucket
+            - name: SCHEMA_S3_PREFIX
+              value: ${DWT_S3_SCHEMA_PREFIX}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              mkdir -p /schema
+              if [[ -z "${SCHEMA_S3_PREFIX}" ]]; then
+                echo "SCHEMA_S3_PREFIX must be set to a folder prefix within the bucket" >&2
+                exit 1
+              fi
+              endpoint_url="${S3_ENDPOINT}"
+              if [[ "${endpoint_url}" != http://* && "${endpoint_url}" != https://* ]]; then
+                endpoint_url="https://${endpoint_url}"
+              fi
+              prefix="${SCHEMA_S3_PREFIX%/}/"
+              echo "Looking up latest schema object under s3://${S3_BUCKET}/${prefix}" >&2
+              latest_key="$(aws s3api list-objects-v2 \
+                --bucket "${S3_BUCKET}" \
+                --prefix "${prefix}" \
+                --query 'sort_by(Contents, &LastModified)[-1].Key' \
+                --output text \
+                --endpoint-url "${endpoint_url}" || true)"
+              if [[ -z "${latest_key}" || "${latest_key}" == "None" ]]; then
+                echo "No schema files found in s3://${S3_BUCKET}/${prefix}" >&2
+                exit 1
+              fi
+              object_name="${latest_key##*/}"
+              echo "Copying ${latest_key} to /schema/${object_name}" >&2
+              aws s3 cp \
+                "s3://${S3_BUCKET}/${latest_key}" \
+                "/schema/${object_name}" \
+                --endpoint-url "${endpoint_url}"
+              echo "${object_name}" > /schema/latest.txt
+          volumeMounts:
+            - name: schema-work
+              mountPath: /schema
+      containers:
+        - name: ddl-runner
+          image: ${DWT_SCHEMA_RUNNER_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HIVE_CONF_DIR
+              value: /opt/hive/conf
+            - name: SCHEMA_S3_PREFIX
+              value: ${DWT_S3_SCHEMA_PREFIX}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              if [[ ! -s /schema/latest.txt ]]; then
+                echo "latest.txt not found; ensure the schema-sync init container completed successfully" >&2
+                exit 1
+              fi
+              latest_name="$(head -n1 /schema/latest.txt)"
+              schema_path="/schema/${latest_name}"
+              if [[ ! -f "${schema_path}" ]]; then
+                echo "Expected schema artifact ${schema_path} is missing" >&2
+                exit 1
+              fi
+              echo "Executing Hive DDL from ${schema_path}" >&2
+              hive -f "${schema_path}"
+              echo "Schema load complete; sleeping to keep container available for logs" >&2
+              sleep infinity
+          volumeMounts:
+            - name: schema-work
+              mountPath: /schema
+            - name: hive-config
+              mountPath: /opt/hive/conf/hive-site.xml
+              subPath: hive-site.xml
+            - name: hive-config
+              mountPath: /opt/hadoop/conf/core-site.xml
+              subPath: core-site.xml
+          resources:
+            requests:
+              cpu: ${DWT_SCHEMA_CPU_REQUEST}
+              memory: ${DWT_SCHEMA_MEMORY_REQUEST}
+            limits:
+              cpu: ${DWT_SCHEMA_CPU_LIMIT}
+              memory: ${DWT_SCHEMA_MEMORY_LIMIT}
+      volumes:
+        - name: schema-work
+          persistentVolumeClaim:
+            claimName: ${DWT_SCHEMA_LOADER_PVC_NAME}
+        - name: hive-config
+          configMap:
+            name: ${DWT_CONFIGMAP_NAME}
+      restartPolicy: Always

--- a/exp-hive-catalog/dwhtrans-catalog-schema-loader-pvc-08.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-schema-loader-pvc-08.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${DWT_SCHEMA_LOADER_PVC_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_SCHEMA_LOADER}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${DWT_SCHEMA_LOADER_STORAGE_SIZE}

--- a/exp-hive-catalog/dwhtrans-catalog-service-06.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-service-06.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${DWT_METASTORE_SERVICE_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}
+spec:
+  selector:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+  ports:
+    - name: thrift
+      port: ${DWT_METASTORE_THRIFT_PORT}
+      targetPort: thrift
+  type: ClusterIP

--- a/exp-hive-catalog/dwhtrans-catalog-serviceaccount-01.yaml
+++ b/exp-hive-catalog/dwhtrans-catalog-serviceaccount-01.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${DWT_SERVICE_ACCOUNT_NAME}
+  labels:
+    app.kubernetes.io/name: ${DWT_APP_NAME}
+    app.kubernetes.io/part-of: ${DWT_PART_OF_LABEL}
+    app.kubernetes.io/component: ${DWT_COMPONENT_METASTORE}
+    exp.openshift.io/area: ${DWT_LABEL_AREA}

--- a/exp-hive-catalog/dwhtrans-catalog-settings.env
+++ b/exp-hive-catalog/dwhtrans-catalog-settings.env
@@ -1,0 +1,68 @@
+# Central configuration for the dwhtrans Hive metastore catalog experiment.
+# Update the values in this file to tailor the deployment for a specific client.
+
+# Global labels and naming
+DWT_APP_NAME=dwhtrans-catalog
+DWT_PART_OF_LABEL=dwhtrans-catalog
+DWT_LABEL_AREA=hive-catalog
+DWT_COMPONENT_METASTORE=metastore
+DWT_COMPONENT_DATABASE=database
+DWT_COMPONENT_SCHEMA_LOADER=schema-loader
+
+# Service account used by all workloads
+DWT_SERVICE_ACCOUNT_NAME=dwhtrans-catalog-serviceaccount
+
+# Hive metastore deployment configuration
+DWT_METASTORE_DEPLOYMENT_NAME=dwhtrans-catalog-deployment
+DWT_METASTORE_IMAGE=quay.io/openshift/origin-hive-metastore:latest
+DWT_METASTORE_REPLICAS=1
+DWT_METASTORE_SERVICE_NAME=dwhtrans-catalog-service
+DWT_METASTORE_THRIFT_PORT=9083
+DWT_METASTORE_CPU_REQUEST=250m
+DWT_METASTORE_MEMORY_REQUEST=1Gi
+DWT_METASTORE_CPU_LIMIT=1
+DWT_METASTORE_MEMORY_LIMIT=2Gi
+DWT_METASTORE_JAVA_TOOL_OPTIONS="-Xms512m -Xmx1g"
+
+# Backing PostgreSQL configuration
+DWT_DB_STATEFULSET_NAME=dwhtrans-catalog-db
+DWT_DB_IMAGE=registry.redhat.io/rhel9/postgresql-15:latest
+DWT_DB_SERVICE_NAME=dwhtrans-catalog-db
+DWT_DB_PORT=5432
+DWT_DB_NAME=metastore
+DWT_DB_USERNAME=metastore
+DWT_DB_PASSWORD=change-me
+DWT_DB_SECRET_NAME=dwhtrans-catalog-db
+DWT_DB_REPLICAS=1
+DWT_DB_STORAGE_SIZE=10Gi
+DWT_DB_STORAGE_CLASS=managed-csi
+DWT_DB_CPU_REQUEST=250m
+DWT_DB_MEMORY_REQUEST=512Mi
+DWT_DB_CPU_LIMIT=1
+DWT_DB_MEMORY_LIMIT=1Gi
+
+# S3/StorageGRID access configuration
+DWT_S3_SECRET_NAME=dwhtrans-catalog-s3
+DWT_S3_ACCESS_KEY=CHANGEME_NETAPP_ACCESS_KEY
+DWT_S3_SECRET_KEY=CHANGEME_NETAPP_SECRET_KEY
+DWT_S3_REGION=us-east-1
+DWT_S3_ENDPOINT=storagegrid.example.com
+DWT_S3_BUCKET=hive-catalog-bucket
+DWT_S3_PATH_STYLE=true
+DWT_S3_SSL_ENABLED=true
+DWT_S3_SCHEMA_PREFIX=schemas/hive-ddl
+
+# Shared ConfigMap
+DWT_CONFIGMAP_NAME=dwhtrans-catalog-config
+
+# Schema loader resources
+DWT_SCHEMA_LOADER_PVC_NAME=dwhtrans-catalog-schema-loader
+DWT_SCHEMA_LOADER_STORAGE_SIZE=1Gi
+DWT_SCHEMA_LOADER_DEPLOYMENT_NAME=dwhtrans-catalog-schema-loader
+DWT_SCHEMA_LOADER_REPLICAS=1
+DWT_SCHEMA_SYNC_IMAGE=amazon/aws-cli:2.15.34
+DWT_SCHEMA_RUNNER_IMAGE=apache/hive:3.1.3
+DWT_SCHEMA_CPU_REQUEST=250m
+DWT_SCHEMA_MEMORY_REQUEST=1Gi
+DWT_SCHEMA_CPU_LIMIT=1
+DWT_SCHEMA_MEMORY_LIMIT=2Gi

--- a/exp-hive-catalog/dwhtrans-catalog-validate.sh
+++ b/exp-hive-catalog/dwhtrans-catalog-validate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECTL_BIN="${KUBECTL:-oc}"
+if ! command -v "${KUBECTL_BIN}" >/dev/null 2>&1; then
+  echo "error: required CLI '${KUBECTL_BIN}' not found in PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/dwhtrans-catalog-settings.env"
+
+if [[ ! -f "${CONFIG_FILE}" ]]; then
+  echo "error: configuration file ${CONFIG_FILE} not found" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "${CONFIG_FILE}"
+set +a
+
+NAMESPACE="${1:-}"
+
+kubectl_args=()
+if [[ -n "${NAMESPACE}" ]]; then
+  kubectl_args+=("-n" "${NAMESPACE}")
+fi
+
+# Ensure the metastore deployment is reported as available before probing it.
+echo "Waiting for Hive metastore deployment to become available..."
+"${KUBECTL_BIN}" wait "deployment/${DWT_METASTORE_DEPLOYMENT_NAME}" \
+  --for=condition=Available --timeout=300s "${kubectl_args[@]}"
+
+# Grab the first metastore pod managed by the deployment.
+mapfile -t metastore_pods < <("${KUBECTL_BIN}" get pods "${kubectl_args[@]}" \
+  -l app.kubernetes.io/name="${DWT_APP_NAME}",app.kubernetes.io/component="${DWT_COMPONENT_METASTORE}" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+if [[ ${#metastore_pods[@]} -eq 0 ]]; then
+  echo "error: no metastore pods found" >&2
+  exit 1
+fi
+
+METASTORE_POD="${metastore_pods[0]}"
+echo "Using metastore pod ${METASTORE_POD}"
+
+# Validate the metastore can reach and interrogate the backing PostgreSQL schema.
+echo "Running schematool connectivity check..."
+"${KUBECTL_BIN}" exec "${kubectl_args[@]}" "${METASTORE_POD}" -- \
+  schematool -dbType postgres -info >/dev/null
+
+echo "Probing metastore thrift port..."
+"${KUBECTL_BIN}" exec "${kubectl_args[@]}" "${METASTORE_POD}" -- \
+  bash -c 'exec 3<>/dev/tcp/localhost/'"${DWT_METASTORE_THRIFT_PORT}"' && exec 3>&- 3<&-'
+
+echo "Hive metastore is reachable and responding."


### PR DESCRIPTION
## Summary
- centralize all customizable catalog settings in `dwhtrans-catalog-settings.env` and render the manifests with those values
- teach the helper scripts to source the shared configuration and update the README with guidance on tailoring deployments per client

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69099cbea2dc8323a6ef2a5f0a8249fd)